### PR TITLE
Update node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Thanks for trying out BAM!  We hope you'll like it! 💥
 ### Prerequisites
 * AWS account
 * AWS CLI
-* Node.js >= 8.10
+* Node.js >= 10
 * NPM
 
 BAM! requires that you have an account with AWS and you have set up an AWS CLI configuration on your local machine.  If you have not already done so, please visit [Configuring the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) for instructions.  BAM! will use the default profile and region you have specified within that profile when interacting with AWS services.
@@ -116,11 +116,11 @@ Lambdas and endpoints deployed from this machine using BAM!:
     description: a description of the lambda
     endpoint:: http://associatedEndpoint/bam
     http methods: GET, POST, DELETE
-    
+
 Other lambdas on AWS
   anotherLambda
   yetAnotherLambda
-  
+
 DynamoDB tables deployed from this machine using BAM!:
   nameOfTable1
     partition key: id (number)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bam-lambda",
-  "version": "2.0.6",
+  "version": "3.0.0",
   "main": "index.js",
   "repository": "https://github.com/bam-lambda/bam.git",
   "author": "bam-lambda",
@@ -53,6 +53,6 @@
   },
   "preferGlobal": true,
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   }
 }

--- a/src/aws/deployLambda.js
+++ b/src/aws/deployLambda.js
@@ -65,7 +65,7 @@ module.exports = async function deployLambda(lambdaName, path, roleName, dir) {
       FunctionName: lambdaName,
       Handler: 'index.handler',
       Role: `arn:aws:iam::${accountNumber}:role/${role}`,
-      Runtime: 'nodejs8.10',
+      Runtime: 'nodejs10.x',
       Description: description,
     };
 

--- a/test/updateLambda.test.js
+++ b/test/updateLambda.test.js
@@ -115,6 +115,7 @@ describe('bam redeploy lambda', () => {
     await writeApi(endpoint, methodPermissionIds, lambdaName, restApiId, path);
 
     try {
+      await delay(30000)
       const preResponse = await asyncHttpsGet(endpoint);
       preResponse.setEncoding('utf8');
       preResponse.on('data', (response) => {
@@ -177,7 +178,7 @@ describe('bam redeploy lambda', () => {
     let responseGet;
     let responseDelete;
     try {
-      await delay(60000);
+      await delay(30000);
       responseGet = await asyncHttpsGet(endpoint);
       responsePost = await asyncHttpsRequest(postOptions);
       responsePut = await asyncHttpsRequest(putOptions);
@@ -230,7 +231,7 @@ describe('bam redeploy lambda', () => {
     let responseGet;
     let responseDelete;
     try {
-      await delay(60000);
+      await delay(30000);
       responseGet = await asyncHttpsGet(endpoint);
       responsePost = await asyncHttpsRequest(postOptions);
       responsePut = await asyncHttpsRequest(putOptions);


### PR DESCRIPTION
**Received the following email from AWS; this this PR just updates the runtime for new lambda functions.**

Hello,

We are contacting you as we have identified that your AWS Account currently has one or more Lambda functions using Node.js 8.10, which will reach its EOL at the end of 2019.

>What’s happening?

The Node community has decided to end support for Node.js 8.x on December 31, 2019 [1]. From this date forward, Node.js 8.x will stop receiving bug fixes, security updates, and/or performance improvements. To ensure that your new and existing functions run on a supported and secure runtime, language runtimes that have reached their EOL are deprecated in AWS [2].

For Node.js 8.x, there will be 2 stages to the runtime deprecation process:

1. Disable Function Create – Beginning January 6, 2020, customers will no longer be able to create functions using Node.js 8.10

2. Disable Function Update – Beginning February 3, 2020, customers will no longer be able to update functions using Node.js 8.10

After this period, both function creation and updates will be disabled permanently. However, existing Node 8.x functions will still be available to process invocation events.

>What do I need to do?

We encourage you to update all of your Node.js 8.10 functions to the newer available runtime version, Node.js 10.x[3]. You should test your functions for compatibility with the Node.js 10.x language version before applying changes to your production functions.