### PR TITLE
Add runtime option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ bam <commandName> [<resourceName>] [--<flag>]
 * *`--rmMethods`*: specifies a HTTP method or methods to remove from endpoint
 * *`--addEndpoint`*: connects endpoint to lambda
 * *`--revokeDb`*: changes role associated with lambda to role specified in user config
+* *`--runtime`*: changes Node runtime of the lambda
 
 ---
 
@@ -116,11 +117,11 @@ Lambdas and endpoints deployed from this machine using BAM!:
     description: a description of the lambda
     endpoint:: http://associatedEndpoint/bam
     http methods: GET, POST, DELETE
-    
+
 Other lambdas on AWS
   anotherLambda
   yetAnotherLambda
-  
+
 DynamoDB tables deployed from this machine using BAM!:
   nameOfTable1
     partition key: id (number)

--- a/src/aws/getLambdaConfig.js
+++ b/src/aws/getLambdaConfig.js
@@ -1,0 +1,10 @@
+const { asyncGetFunction } = require('./awsFunctions');
+
+module.exports = async function getLambdaConfig(lambdaName) {
+  try {
+    const data = await asyncGetFunction({ FunctionName: lambdaName });
+    return data.Configuration;
+  } catch (err) {
+    return err;
+  }
+};

--- a/src/aws/updateLambda.js
+++ b/src/aws/updateLambda.js
@@ -16,7 +16,7 @@ const {
 
 const cwd = process.cwd();
 
-module.exports = async function updateLambda(lambdaName, path, roleName, dir) {
+module.exports = async function updateLambda(lambdaName, path, roleName, dir, runtime) {
   const stagingPath = getStagingPath(path);
   const renameLambdaFileToIndexJs = async () => {
     await rename(`${stagingPath}/${lambdaName}/${lambdaName}.js`,
@@ -45,7 +45,7 @@ module.exports = async function updateLambda(lambdaName, path, roleName, dir) {
   const zipContents = await readFile(zippedFileName);
 
   const updateAwsLambda = async () => {
-    await updateLambdaConfig(lambdaName, path, roleName);
+    await updateLambdaConfig(lambdaName, path, roleName, runtime);
     const codeParams = {
       FunctionName: lambdaName,
       ZipFile: zipContents,

--- a/src/aws/updateLambdaConfig.js
+++ b/src/aws/updateLambdaConfig.js
@@ -1,5 +1,5 @@
 const { asyncLambdaUpdateFunctionConfiguration } = require('./awsFunctions');
-const getLambda = require('./getLambda');
+const getLambdaConfig = require('./getLambdaConfig');
 const { bamError } = require('../util/logger');
 const { asyncGetRegion } = require('../util/getRegion');
 const getDescription = require('../util/getDescription');
@@ -10,26 +10,14 @@ const {
   writeLambda,
 } = require('../util/fileUtils');
 
-const getConfig = async (lambdaName) => {
-  let role, runtime;
-
-  try {
-    const data = await getLambda(lambdaName);
-    role = data.Configuration.Role;
-    runtime = data.Configuration.Runtime;
-  } catch (err) {
-    bamError(err);
-  }
-
-  return [role, runtime];
-};
-
 module.exports = async function updateLambdaConfig(lambdaName, path, roleName, runtime) {
   const config = await readConfig(path);
   const { accountNumber } = config;
   const region = await asyncGetRegion();
   const description = await getDescription(lambdaName, path);
-  const [ currentRoleArn, currentRuntime ] = await getConfig(lambdaName);
+  const lambdaConfig = await getLambdaConfig(lambdaName);
+  const currentRoleArn = lambdaConfig.Role;
+  const currentRuntime = lambdaConfig.Runtime;
 
   const lambdas = await readLambdasLibrary(path);
   const lambda = lambdas[region][lambdaName];

--- a/src/commands/redeploy.js
+++ b/src/commands/redeploy.js
@@ -18,6 +18,7 @@ const {
   validateLambdaReDeployment,
   validateLambdaDirReDeployment,
   validateRoleAssumption,
+  validateNodeRuntime,
 } = require('../util/validations');
 
 const {
@@ -90,6 +91,19 @@ module.exports = async function redeploy(resourceName, path, options) {
       return;
     }
     roleName = userRole;
+  }
+
+  const runtimeOption = getOption(options, 'runtime');
+  const newRuntime = options[runtimeOption] && options[runtimeOption][0];
+  let runtime;
+
+  if (newRuntime) {
+    const invalidRuntimeMsg = await validateNodeRuntime(newRuntime)
+    if (invalidRuntimeMsg) {
+      bamWarn(invalidRuntimeMsg);
+      return;
+    }
+    runtime = newRuntime;
   }
 
   const resolveHttpMethodsFromOptions = () => {
@@ -214,7 +228,7 @@ module.exports = async function redeploy(resourceName, path, options) {
     writeLambda(lambdaData, path);
   }
 
-  const asyncFuncParams = [resourceName, path, roleName, deployDir];
+  const asyncFuncParams = [resourceName, path, roleName, deployDir, runtime];
   const lambdaUpdateSuccess = await bamBam(updateLambda, { asyncFuncParams });
 
   if (lambdaUpdateSuccess) {

--- a/src/commands/redeploy.js
+++ b/src/commands/redeploy.js
@@ -94,14 +94,14 @@ module.exports = async function redeploy(resourceName, path, options) {
     roleName = userRole;
   }
 
-  const runtimeOption = getOption(options, 'runtime');
-  let runtime = (options[runtimeOption] && options[runtimeOption][0]);
-
-  if (!runtime) {
+  const getCurrentRuntime = async () => {
     const lambdaConfig = await getLambdaConfig(resourceName);
-    runtime = lambdaConfig.Runtime;
-  }
+    return lambdaConfig.Runtime;
+  };
 
+  const runtimeOption = getOption(options, 'runtime');
+  const newRuntime = (options[runtimeOption] && options[runtimeOption][0]);
+  const runtime = newRuntime || await getCurrentRuntime();
   const invalidRuntimeMsg = await validateNodeRuntime(runtime);
   if (invalidRuntimeMsg) {
     bamWarn(invalidRuntimeMsg);

--- a/src/util/commandDescriptions.js
+++ b/src/util/commandDescriptions.js
@@ -22,6 +22,7 @@ module.exports = {
       { name: 'rmmethods', description: 'specifies HTTP method(s) to be removed from the API Gateway' },
       { name: 'revokeDb', description: 'changes role associated with lambda to role specified in user config' },
       { name: 'addEndpoint', description: 'connects endpoint (if none exists) to lamdba' },
+      // TODO: add runtime option
     ],
     hasResource: true,
   },

--- a/src/util/commandDescriptions.js
+++ b/src/util/commandDescriptions.js
@@ -22,7 +22,7 @@ module.exports = {
       { name: 'rmmethods', description: 'specifies HTTP method(s) to be removed from the API Gateway' },
       { name: 'revokeDb', description: 'changes role associated with lambda to role specified in user config' },
       { name: 'addEndpoint', description: 'connects endpoint (if none exists) to lamdba' },
-      // TODO: add runtime option
+      { name: 'runtime', description: 'changes Node runtime of the lambda'},
     ],
     hasResource: true,
   },

--- a/src/util/validationMessages.js
+++ b/src/util/validationMessages.js
@@ -49,7 +49,7 @@ const getInvalidRuntimeMsg = (runtime) => {
     validNodeRuntimesStr = `"${validNodeRuntimes[0]}"`;
   }
 
-  return `${msgAfterAction('runtime', runtime, 'invalid', 'is')}. Please update to ${validNodeRuntimesStr} using the "runtime" option. Ex: bam redeploy myLambda --runtime nodejs10.x`;
+  return `${msgAfterAction('runtime', runtime, 'invalid', 'is')}. Please update to ${validNodeRuntimesStr} using the "runtime" option. Ex: bam redeploy myLambda --runtime nodejs10.x\nNOTE: This update may include breaking changes. Please refer to the Node documentation and make any necessary changes to your lambda function first.`;
 };
 
 const customizeLambdaWarnings = (name) => {

--- a/src/util/validationMessages.js
+++ b/src/util/validationMessages.js
@@ -49,7 +49,7 @@ const getInvalidRuntimeMsg = (runtime) => {
     validNodeRuntimesStr = `"${validNodeRuntimes[0]}"`;
   }
 
-  return `${msgAfterAction('runtime', runtime, 'invalid', 'is')}. Please use ${validNodeRuntimesStr}.`;
+  return `${msgAfterAction('runtime', runtime, 'invalid', 'is')}. Please update to ${validNodeRuntimesStr} using the "runtime" option. Ex: bam redeploy myLambda --runtime nodejs10.x`;
 };
 
 const customizeLambdaWarnings = (name) => {

--- a/src/util/validationMessages.js
+++ b/src/util/validationMessages.js
@@ -41,7 +41,7 @@ const getInvalidRuntimeMsg = (runtime) => {
   const totalValidRuntimes = validNodeRuntimes.length;
   let validNodeRuntimesStr;
 
-  if (totalValidRuntimes == 2) {
+  if (totalValidRuntimes === 2) {
     validNodeRuntimesStr = `"${validNodeRuntimes.join('" or "')}"`
   } else if (totalValidRuntimes > 2) {
     validNodeRuntimesStr = `"${validNodeRuntimes.slice(0, -1).join('", "')}", or "${validNodeRuntimes.slice(-1)}"`;

--- a/src/util/validationMessages.js
+++ b/src/util/validationMessages.js
@@ -1,6 +1,7 @@
 const { msgAfterAction } = require('./logger');
 const { distinctElements } = require('./fileUtils');
 
+const validNodeRuntimes = ['nodejs10.x'];
 const validMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'ANY'];
 const validMethodsStr = `${validMethods.slice(0, -2).join(', ')}, and ${validMethods.slice(-1)}`;
 const pluralizeMethodsMsg = msg => msg.replace('Method', 'Methods')
@@ -34,6 +35,21 @@ const getCannotRemoveMethodMadeInConsoleMsg = (removeMethods, existingMethods) =
   if (nonexistentMethods.length > 1) msg = pluralizeMethodsMsg(msg);
 
   return `${msg}.\nConsider using "bam list" to see which methods can be removed.`;
+};
+
+const getInvalidRuntimeMsg = (runtime) => {
+  const totalValidRuntimes = validNodeRuntimes.length;
+  let validNodeRuntimesStr;
+
+  if (totalValidRuntimes == 2) {
+    validNodeRuntimesStr = `"${validNodeRuntimes.join('" or "')}"`
+  } else if (totalValidRuntimes > 2) {
+    validNodeRuntimesStr = `"${validNodeRuntimes.slice(0, -1).join('", "')}", or "${validNodeRuntimes.slice(-1)}"`;
+  } else {
+    validNodeRuntimesStr = `"${validNodeRuntimes[0]}"`;
+  }
+
+  return `${msgAfterAction('runtime', runtime, 'invalid', 'is')}. Please use ${validNodeRuntimesStr}.`;
 };
 
 const customizeLambdaWarnings = (name) => {
@@ -78,9 +94,17 @@ const customizeRoleWarnings = name => (
   }
 );
 
+const customizeConfigWarnings = runtime => (
+  {
+    nodeRuntimeRequired: `${msgAfterAction('runtime', runtime, 'invalid', 'is')}. BAM! only supports Node runtimes.`,
+    invalidNodeRuntime: getInvalidRuntimeMsg(runtime),
+  }
+);
+
 module.exports = {
   customizeLambdaWarnings,
   customizeApiWarnings,
   customizeTableWarnings,
   customizeRoleWarnings,
+  customizeConfigWarnings,
 };

--- a/src/util/validations.js
+++ b/src/util/validations.js
@@ -96,11 +96,11 @@ const removeMethodsDeployedPreviouslyWithBam = async ({
   return result.length === 0;
 };
 
-const isANodeRuntime = async (name) => {
+const isANodeRuntime = (name) => {
   return name.includes('node');
 };
 
-const runtimeIsValid = async (name) => {
+const runtimeIsValid = (name) => {
   const validNodeRuntimes = ['nodejs10.x'];
   return validNodeRuntimes.includes(name);
 };

--- a/src/util/validations.js
+++ b/src/util/validations.js
@@ -17,6 +17,7 @@ const {
   customizeApiWarnings,
   customizeTableWarnings,
   customizeRoleWarnings,
+  customizeConfigWarnings,
 } = require('./validationMessages');
 
 const cwd = process.cwd();
@@ -93,6 +94,15 @@ const removeMethodsDeployedPreviouslyWithBam = async ({
   const existingBamMethods = api ? Object.keys(api.methodPermissionIds) : [];
   const result = filteredRemoveMethods.filter(m => !existingBamMethods.includes(m));
   return result.length === 0;
+};
+
+const isANodeRuntime = async (name) => {
+  return name.includes('node');
+};
+
+const runtimeIsValid = async (name) => {
+  const validNodeRuntimes = ['nodejs10.x'];
+  return validNodeRuntimes.includes(name);
 };
 
 const validateResource = async (resourceData, validations, customWarnings) => {
@@ -291,8 +301,24 @@ const validateApiMethods = async (resourceData) => {
       affirmative: true,
     },
   ];
-
   const status = await validateResource(resourceData, validations, customizeApiWarnings);
+  return status;
+};
+
+const validateNodeRuntime = async (name) => {
+  const validations = [
+    {
+      validation: isANodeRuntime,
+      feedbackType: 'nodeRuntimeRequired',
+      affirmative: false,
+    },
+    {
+      validation: runtimeIsValid,
+      feedbackType: 'invalidNodeRuntime',
+      affirmative: false,
+    }
+  ];
+  const status = await validateResource(name, validations, customizeConfigWarnings);
   return status;
 };
 
@@ -308,4 +334,5 @@ module.exports = {
   validateApiMethods,
   validateTableCreation,
   validateRoleAssumption,
+  validateNodeRuntime,
 };

--- a/test/updateLambda.test.js
+++ b/test/updateLambda.test.js
@@ -115,6 +115,7 @@ describe('bam redeploy lambda', () => {
     await writeApi(endpoint, methodPermissionIds, lambdaName, restApiId, path);
 
     try {
+      await delay(30000);
       const preResponse = await asyncHttpsGet(endpoint);
       preResponse.setEncoding('utf8');
       preResponse.on('data', (response) => {
@@ -177,7 +178,7 @@ describe('bam redeploy lambda', () => {
     let responseGet;
     let responseDelete;
     try {
-      await delay(60000);
+      await delay(30000);
       responseGet = await asyncHttpsGet(endpoint);
       responsePost = await asyncHttpsRequest(postOptions);
       responsePut = await asyncHttpsRequest(putOptions);
@@ -230,7 +231,7 @@ describe('bam redeploy lambda', () => {
     let responseGet;
     let responseDelete;
     try {
-      await delay(60000);
+      await delay(30000);
       responseGet = await asyncHttpsGet(endpoint);
       responsePost = await asyncHttpsRequest(postOptions);
       responsePut = await asyncHttpsRequest(putOptions);


### PR DESCRIPTION
Node 8.10 is losing support at the end of the year. 

My [previous PR](https://github.com/bam-lambda/bam/pull/181) updates the runtime configuration of newly created lambdas.

This PR adds a `runtime` option to the `redeploy` command so that users can update their existing lambdas to an actively supported runtime without downtime, and therefore, continue to use BAM! to maintain these functions.

BAM! is still more or less opinionated about the runtime configuration:
- You cannot configure the runtime when creating lambda.
- You cannot configure the runtime to a non-Node runtime when updating a lambda.
- You cannot configure the runtime to an Node runtime that has already reached EOL (or, in the case of Node 8.10, will soon reach its EOL).