### PR TITLE
Update Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ DynamoDB tables deployed from this machine using BAM!:
 #### Version 5.0.0 (November 2023)
 * Updated default Node runtime to `nodejs18.x`.
 * Added `nodejs16.x` and `nodejs18.x` to valid runtimes for Lambda functions.
-* Removed `nodejs14.x` from valid runtimes for Lambda functions because it will no longer be supported after November 27, 2023 (https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).
+* Removed `nodejs12.x` and `nodejs14.x` from valid runtimes for Lambda functions because they are no longer supported (https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).
 #### Version 4.0.0 (August 2021)
 * Updated default Node runtime to `nodejs14.x`.
 * Added `nodejs12.x` to valid runtimes for Lambda functions.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Thanks for trying out BAM!  We hope you'll like it! 💥
 ### Prerequisites
 * AWS account
 * AWS CLI
-* Node.js >= 14
+* Node.js >= 18
 * NPM
 
 BAM! requires that you have an account with AWS and you have set up an AWS CLI configuration on your local machine.  If you have not already done so, please visit [Configuring the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) for instructions.  BAM! will use the default profile and region you have specified within that profile when interacting with AWS services.
@@ -180,6 +180,10 @@ DynamoDB tables deployed from this machine using BAM!:
 * [Amazon DynamoDB Document Client SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html)
 
 ## Release Notes
+#### Version 5.0.0 (November 2023)
+* Updated default Node runtime to `nodejs18.x`.
+* Added `nodejs16.x` and `nodejs18.x` to valid runtimes for Lambda functions.
+* Removed `nodejs14.x` from valid runtimes for Lambda functions because it will no longer be supported after November 27, 2023 (https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).
 #### Version 4.0.0 (August 2021)
 * Updated default Node runtime to `nodejs14.x`.
 * Added `nodejs12.x` to valid runtimes for Lambda functions.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "preferGlobal": true,
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bam-lambda",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "main": "index.js",
   "repository": "https://github.com/bam-lambda/bam.git",
   "author": "bam-lambda",

--- a/src/aws/deployLambda.js
+++ b/src/aws/deployLambda.js
@@ -65,7 +65,7 @@ module.exports = async function deployLambda(lambdaName, path, roleName, dir) {
       FunctionName: lambdaName,
       Handler: 'index.handler',
       Role: `arn:aws:iam::${accountNumber}:role/${role}`,
-      Runtime: 'nodejs14.x',
+      Runtime: 'nodejs18.x',
       Description: description,
     };
 

--- a/src/util/validationMessages.js
+++ b/src/util/validationMessages.js
@@ -1,7 +1,7 @@
 const { msgAfterAction } = require('./logger');
 const { distinctElements } = require('./fileUtils');
 
-const validNodeRuntimes = ['nodejs12.x', 'nodejs14.x'];
+const validNodeRuntimes = ['nodejs16.x', 'nodejs18.x'];
 const validMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'ANY'];
 const validMethodsStr = `${validMethods.slice(0, -2).join(', ')}, and ${validMethods.slice(-1)}`;
 const pluralizeMethodsMsg = msg => msg.replace('Method', 'Methods')
@@ -49,7 +49,7 @@ const getInvalidRuntimeMsg = (runtime) => {
     validNodeRuntimesStr = `"${validNodeRuntimes[0]}"`;
   }
 
-  return `${msgAfterAction('runtime', runtime, 'invalid', 'is')}. Please update to ${validNodeRuntimesStr} using the "runtime" option. Ex: bam redeploy myLambda --runtime nodejs14.x\nNOTE: This update may include breaking changes. Please refer to the Node documentation and make any necessary changes to your lambda function first.`;
+  return `${msgAfterAction('runtime', runtime, 'invalid', 'is')}. Please update to ${validNodeRuntimesStr} using the "runtime" option. Ex: bam redeploy myLambda --runtime nodejs18.x\nNOTE: This update may include breaking changes. Please refer to the Node documentation and make any necessary changes to your lambda function first.`;
 };
 
 const customizeLambdaWarnings = (name) => {

--- a/src/util/validations.js
+++ b/src/util/validations.js
@@ -108,7 +108,7 @@ const isANodeRuntime = (name) => {
 };
 
 const runtimeIsValid = (name) => {
-  const validNodeRuntimes = ['nodejs12.x', 'nodejs14.x'];
+  const validNodeRuntimes = ['nodejs16.x', 'nodejs18.x'];
   return validNodeRuntimes.includes(name);
 };
 

--- a/test/updateLambda.test.js
+++ b/test/updateLambda.test.js
@@ -127,6 +127,7 @@ describe('bam redeploy lambda', () => {
       await writeFile(`${cwd}/${lambdaName}.js`, testLambdaWithDependenciesFile);
       await redeploy(lambdaName, path, {});
 
+      await delay(30000);
       const postResponse = await asyncHttpsGet(endpoint);
       postResponse.setEncoding('utf8');
       postResponse.on('data', (response) => {


### PR DESCRIPTION
**Received the following in an email from AWS:**

> We are contacting you as we have identified that your AWS Account currently has one or more Lambda functions using the Node.js 14 runtime.
> 
> We are ending support for Node.js 14 in AWS Lambda. This follows Node.js 14 End-Of-Life (EOL) reached on April 30, 2023 [1].
> 
> As described in the Lambda runtime support policy [2], end of support for language runtimes in Lambda happens in two stages. Starting November 27, 2023, Lambda will no longer apply security patches and other updates to the Node.js 14 runtime used by Lambda functions, and functions using Node.js 14 will no longer be eligible for technical support. In addition, you will no longer be able to create new Lambda functions using the Node.js 14 runtime. Starting January 25, 2024, you will no longer be able to update existing functions using the Node.js 14 runtime.
> 
> We recommend that you upgrade your existing Node.js 14 functions to Node.js 18 before November 27, 2023.
> 
> End of support does not impact function execution. Your functions will continue to run. However, they will be running on an unsupported runtime which is no longer maintained or patched by the AWS Lambda team.
> 
> This notification is generated for functions using the Node.js 14 runtime for the $LATEST function version. For a list of your affected Lambda functions, please see the 'Affected resources" tab of your AWS Health Dashboard
> 
> The following command shows how to use the AWS CLI [3] to list all functions in a specific region using Node.js 14, including published function versions. To find all such functions in your account, repeat this command for each region:
> 
> aws lambda list-functions --function-version ALL --region us-east-1 --output text --query "Functions[?Runtime=='nodejs14.x'].FunctionArn"
> 
> If you have any concerns or require further assistance, please contact AWS Support [4].
> 
> [1] https://endoflife.date/nodejs
> [2] https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html

**Changes**:
This PR updates the runtime for new lambda functions, valid runtimes for redeployed lambda functions, and the recommended runtime for BAM!.

[Node 16.0.0 release notes](https://nodejs.org/en/blog/release/v16.0.0)
[Node 18.0.0 release notes](https://nodejs.org/en/blog/release/v18.0.0)